### PR TITLE
Test NewHost set external opts

### DIFF
--- a/p2p_test.go
+++ b/p2p_test.go
@@ -151,17 +151,17 @@ func Test_NewHost_ExternalOpts_NoMasterKey(t *testing.T) {
 	opts := []Option{
 		Port(30001),
 		SecureIO(),
-		ExternalHostName("external-host"),
+		ExternalHostName("127.0.0.1"),
 		ExternalPort(4000),
 	}
 
 	host, err := NewHost(ctx, opts...)
 	assert.NoError(t, err)
-	assert.Equal(t, "external-host", host.cfg.ExternalHostName)
+	assert.Equal(t, "127.0.0.1", host.cfg.ExternalHostName)
 	assert.Equal(t, 4000, host.cfg.ExternalPort)
 	assert.Equal(t, "", host.cfg.MasterKey)
 
-	masterKey := fmt.Sprintf("%s:%d", "external-host", 4000)
+	masterKey := fmt.Sprintf("%s:%d", "127.0.0.1", 4000)
 	v1b := cid.V1Builder{Codec: cid.Raw, MhType: multihash.SHA2_256}
 	cid, err := v1b.Sum([]byte(masterKey))
 	assert.NoError(t, err)
@@ -175,14 +175,14 @@ func Test_NewHost_ExternalOpts_MasterKey(t *testing.T) {
 	opts := []Option{
 		Port(30001),
 		SecureIO(),
-		ExternalHostName("external-host"),
+		ExternalHostName("127.0.0.1"),
 		ExternalPort(4000),
 		MasterKey("mk1"),
 	}
 
 	host, err := NewHost(ctx, opts...)
 	assert.NoError(t, err)
-	assert.Equal(t, "external-host", host.cfg.ExternalHostName)
+	assert.Equal(t, "127.0.0.1", host.cfg.ExternalHostName)
 	assert.Equal(t, 4000, host.cfg.ExternalPort)
 	assert.Equal(t, "mk1", host.cfg.MasterKey)
 

--- a/p2p_test.go
+++ b/p2p_test.go
@@ -175,14 +175,14 @@ func Test_NewHost_ExternalOpts_MasterKey(t *testing.T) {
 	opts := []Option{
 		Port(30001),
 		SecureIO(),
-		ExternalHostName("127.0.0.1"),
+		ExternalHostName("0.0.0.0"),
 		ExternalPort(4000),
 		MasterKey("mk1"),
 	}
 
 	host, err := NewHost(ctx, opts...)
 	assert.NoError(t, err)
-	assert.Equal(t, "127.0.0.1", host.cfg.ExternalHostName)
+	assert.Equal(t, "0.0.0.0", host.cfg.ExternalHostName)
 	assert.Equal(t, 4000, host.cfg.ExternalPort)
 	assert.Equal(t, "mk1", host.cfg.MasterKey)
 

--- a/p2p_test.go
+++ b/p2p_test.go
@@ -3,13 +3,14 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"github.com/libp2p/go-libp2p-core/network"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )
@@ -141,4 +142,21 @@ func TestUnicast_ReadReturnedStream(t *testing.T) {
 
 	require.NoError(t, p1.Close())
 	require.NoError(t, p2.Close())
+}
+
+func Test_NewHost_ExternalOpts(t *testing.T) {
+	ctx := context.Background()
+	opts := []Option{
+		Port(30001),
+		SecureIO(),
+		ExternalHostName("external-host"),
+		ExternalPort(4000),
+		MasterKey("1"),
+	}
+	host, err := NewHost(ctx, opts...)
+	assert.NoError(t, err)
+	assert.Equal(t, "external-host", host.cfg.ExternalHostName)
+	assert.Equal(t, 4000, host.cfg.ExternalPort)
+
+	defer host.Close()
 }


### PR DESCRIPTION
**Problem**

When hosting nodes in private subnets, it's not easy to setup the addressing as internal nodes may also want to access the node so we have to choose which address we specify as the advertising address of the node.

https://app.asana.com/0/1162222114887946/list

**Solution**

Test set g-p2p fields ExternalHostName and ExternalPort.